### PR TITLE
Add type to vehicles

### DIFF
--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,2 +1,8 @@
 class Vehicle < ApplicationRecord
+  enum type: {
+    Truck: 0,
+    Van: 1,
+    Car: 2,
+    Motorcycle: 3
+  }, _suffix: true
 end

--- a/app/views/vehicles/_form.html.erb
+++ b/app/views/vehicles/_form.html.erb
@@ -12,6 +12,11 @@
   <% end %>
 
   <div class="field">
+    <%= form.label :type %>
+    <%= form.collection_select :type, Vehicle.types.map{ |type| [type.first, type.first] }, :first, :second %>
+  </div>
+
+    <div class="field">
     <%= form.label :manufacturer %>
     <%= form.text_field :manufacturer %>
   </div>

--- a/app/views/vehicles/index.html.erb
+++ b/app/views/vehicles/index.html.erb
@@ -16,6 +16,7 @@
     <% @vehicles.each do |vehicle| %>
       <tr>
         <td><%= vehicle.manufacturer %></td>
+        <td><%= vehicle.type %></td>
         <td><%= vehicle.model %></td>
         <td><%= vehicle.license_plate %></td>
         <td><%= link_to 'Show', vehicle %></td>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -1,6 +1,11 @@
 <p id="notice"><%= notice %></p>
 
 <p>
+  <strong>Type:</strong>
+  <%= @vehicle.type %>
+</p>
+
+<p>
   <strong>Manufacturer:</strong>
   <%= @vehicle.manufacturer %>
 </p>

--- a/db/migrate/20210526025647_add_type_to_vehicle.rb
+++ b/db/migrate/20210526025647_add_type_to_vehicle.rb
@@ -1,0 +1,5 @@
+class AddTypeToVehicle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :vehicles, :type, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_25_175306) do
+ActiveRecord::Schema.define(version: 2021_05_26_025647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "customers", force: :cascade do |t|
+    t.string "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "drivers", force: :cascade do |t|
     t.string "first_name"
@@ -30,6 +36,7 @@ ActiveRecord::Schema.define(version: 2021_05_25_175306) do
     t.string "license_plate"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "type"
   end
 
 end


### PR DESCRIPTION
## Add type field to vehicles
---
### Context

Add type field to the vehicle table and its views so that the user can select an option, such as Truck, Van, Car or Motorcycle

### Content

- [x] Generate the migration to the database
- [x] Add enum options to the model
- [x] Add the type field to the views