### PR TITLE
Add Shipments Table

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,0 +1,61 @@
+class ShipmentsController < ApplicationController
+  before_action :set_shipment, only: %i[ show edit update destroy ]
+
+  def index
+    @shipments = Shipment.all
+  end
+
+  def show
+  end
+
+  def new
+    @shipment = Shipment.new
+  end
+
+  def edit
+  end
+
+  def create
+    @shipment = Shipment.new(shipment_params)
+
+    respond_to do |format|
+      if @shipment.save
+        format.html { redirect_to @shipment, notice: "Shipment was successfully created." }
+        format.json { render :show, status: :created, location: @shipment }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @shipment.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @shipment.update(shipment_params)
+        format.html { redirect_to @shipment, notice: "Shipment was successfully updated." }
+        format.json { render :show, status: :ok, location: @shipment }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @shipment.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @shipment.destroy
+    respond_to do |format|
+      format.html { redirect_to shipments_url, notice: "Shipment was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    def set_shipment
+      @shipment = Shipment.find(params[:id])
+    end
+
+    def shipment_params
+      params.require(:shipment).permit(:driver_id, :vehicle_id, :customer_id, :shipment_type, :invoice_number, :cargo_checker, :warehouse, :dock, :date, :hour)
+    end
+end

--- a/app/helpers/shipments_helper.rb
+++ b/app/helpers/shipments_helper.rb
@@ -1,0 +1,2 @@
+module ShipmentsHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,17 +1,4 @@
-// This file is automatically compiled by Webpack, along with any other files
-// present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript and only use these pack files to reference
-// that code so it'll be compiled.
-
 require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-
-
-// Uncomment to copy all static images under ../images to the output folder and reference
-// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
-// or the `imagePath` JavaScript helper below.
-//
-// const images = require.context('../images', true)
-// const imagePath = (name) => images(name, true)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,3 @@
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
 
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,2 +1,4 @@
 class Customer < ApplicationRecord
+  has_many :shipments
+
 end

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -1,2 +1,4 @@
 class Driver < ApplicationRecord
+  has_many :shipments
+  has_many :vehicles, through: :shipments
 end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -1,0 +1,16 @@
+class Shipment < ApplicationRecord
+  belongs_to :driver
+  belongs_to :vehicle
+  belongs_to :customer
+
+  enum shipment_type: {
+    Delivery: 0,
+    Collect: 1
+  }, _suffix: true
+
+  enum warehouse: {
+    Healthcare: 0,
+    HighTech: 1
+  }, _suffix: true
+
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,4 +1,7 @@
 class Vehicle < ApplicationRecord
+  has_many :shipments
+  has_many :drivers, through: :shipments
+
   enum vehicle_type: {
     Truck: 0,
     Van: 1,

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -1,0 +1,67 @@
+<%= form_with(model: shipment, local: true) do |form| %>
+  <% if shipment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(shipment.errors.count, "error") %> prohibited this shipment from being saved:</h2>
+
+      <ul>
+        <% shipment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :driver_id %>
+    <%= form.text_field :driver_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :vehicle_id %>
+    <%= form.text_field :vehicle_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :customer_id %>
+    <%= form.text_field :customer_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :shipment_type %>
+    <%= form.collection_select :shipment_type, Shipment.shipment_types.map{ |type| [type.first, type.first] }, :first, :second %>
+  </div>
+
+  <div class="field">
+    <%= form.label :invoice_number %>
+    <%= form.text_field :invoice_number %>
+  </div>
+
+  <div class="field">
+    <%= form.label :cargo_checker %>
+    <%= form.text_field :cargo_checker %>
+  </div>
+
+  <div class="field">
+    <%= form.label :warehouse %>
+    <%= form.collection_select :warehouse, Shipment.warehouses.map{ |warehouse| [warehouse.first, warehouse.first] }, :first, :second %>
+  </div>
+
+  <div class="field">
+    <%= form.label :dock %>
+    <%= form.text_field :dock %>
+  </div>
+
+  <div class="field">
+    <%= form.label :date %>
+    <%= form.date_select :date %>
+  </div>
+
+  <div class="field">
+    <%= form.label :hour %>
+    <%= form.time_select :hour %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/shipments/_shipment.json.jbuilder
+++ b/app/views/shipments/_shipment.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! shipment, :id, :driver_id, :vehicle_id, :customer_id, :shipment_type, :invoice_number, :cargo_checker, :warehouse, :dock, :date, :hour, :created_at, :updated_at
+json.url shipment_url(shipment, format: :json)

--- a/app/views/shipments/edit.html.erb
+++ b/app/views/shipments/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Shipment</h1>
+
+<%= render 'form', shipment: @shipment %>
+
+<%= link_to 'Show', @shipment %> |
+<%= link_to 'Back', shipments_path %>

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -1,0 +1,45 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Shipments</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Driver</th>
+      <th>Vehicle</th>
+      <th>Customer</th>
+      <th>Shipment type</th>
+      <th>Invoice number</th>
+      <th>Cargo checker</th>
+      <th>Warehouse</th>
+      <th>Dock</th>
+      <th>Date</th>
+      <th>Hour</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @shipments.each do |shipment| %>
+      <tr>
+        <td><%= shipment.driver_id %></td>
+        <td><%= shipment.vehicle_id %></td>
+        <td><%= shipment.customer_id %></td>
+        <td><%= shipment.shipment_type %></td>
+        <td><%= shipment.invoice_number %></td>
+        <td><%= shipment.cargo_checker %></td>
+        <td><%= shipment.warehouse %></td>
+        <td><%= shipment.dock %></td>
+        <td><%= shipment.date %></td>
+        <td><%= shipment.hour %></td>
+        <td><%= link_to 'Show', shipment %></td>
+        <td><%= link_to 'Edit', edit_shipment_path(shipment) %></td>
+        <td><%= link_to 'Destroy', shipment, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Shipment', new_shipment_path %>

--- a/app/views/shipments/index.json.jbuilder
+++ b/app/views/shipments/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @shipments, partial: "shipments/shipment", as: :shipment

--- a/app/views/shipments/new.html.erb
+++ b/app/views/shipments/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Shipment</h1>
+
+<%= render 'form', shipment: @shipment %>
+
+<%= link_to 'Back', shipments_path %>

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -1,0 +1,54 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Driver:</strong>
+  <%= @shipment.driver_id %>
+</p>
+
+<p>
+  <strong>Vehicle:</strong>
+  <%= @shipment.vehicle_id %>
+</p>
+
+<p>
+  <strong>Customer:</strong>
+  <%= @shipment.customer_id %>
+</p>
+
+<p>
+  <strong>Shipment type:</strong>
+  <%= @shipment.shipment_type %>
+</p>
+
+<p>
+  <strong>Invoice number:</strong>
+  <%= @shipment.invoice_number %>
+</p>
+
+<p>
+  <strong>Cargo checker:</strong>
+  <%= @shipment.cargo_checker %>
+</p>
+
+<p>
+  <strong>Warehouse:</strong>
+  <%= @shipment.warehouse %>
+</p>
+
+<p>
+  <strong>Dock:</strong>
+  <%= @shipment.dock %>
+</p>
+
+<p>
+  <strong>Date:</strong>
+  <%= @shipment.date %>
+</p>
+
+<p>
+  <strong>Hour:</strong>
+  <%= @shipment.hour %>
+</p>
+
+<%= link_to 'Edit', edit_shipment_path(@shipment) %> |
+<%= link_to 'Back', shipments_path %>

--- a/app/views/shipments/show.json.jbuilder
+++ b/app/views/shipments/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "shipments/shipment", shipment: @shipment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :shipments
   resources :customers
   resources :vehicles
   resources :drivers

--- a/db/migrate/20210527002912_create_shipments.rb
+++ b/db/migrate/20210527002912_create_shipments.rb
@@ -1,0 +1,18 @@
+class CreateShipments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shipments do |t|
+      t.references :driver, null: false, foreign_key: true
+      t.references :vehicle, null: false, foreign_key: true
+      t.references :customer, null: false, foreign_key: true
+      t.integer :shipment_type
+      t.string :invoice_number
+      t.string :cargo_checker
+      t.integer :warehouse
+      t.string :dock
+      t.date :date
+      t.time :hour
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,18 +1,5 @@
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
+ActiveRecord::Schema.define(version: 2021_05_27_002912) do
 
-ActiveRecord::Schema.define(version: 2021_05_26_025647) do
-
-  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "customers", force: :cascade do |t|
@@ -30,6 +17,24 @@ ActiveRecord::Schema.define(version: 2021_05_26_025647) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "shipments", force: :cascade do |t|
+    t.bigint "driver_id", null: false
+    t.bigint "vehicle_id", null: false
+    t.bigint "customer_id", null: false
+    t.integer "shipment_type"
+    t.string "invoice_number"
+    t.string "cargo_checker"
+    t.integer "warehouse"
+    t.string "dock"
+    t.date "date"
+    t.time "hour"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id"], name: "index_shipments_on_customer_id"
+    t.index ["driver_id"], name: "index_shipments_on_driver_id"
+    t.index ["vehicle_id"], name: "index_shipments_on_vehicle_id"
+  end
+
   create_table "vehicles", force: :cascade do |t|
     t.string "manufacturer"
     t.string "model"
@@ -39,4 +44,7 @@ ActiveRecord::Schema.define(version: 2021_05_26_025647) do
     t.integer "vehicle_type"
   end
 
+  add_foreign_key "shipments", "customers"
+  add_foreign_key "shipments", "drivers"
+  add_foreign_key "shipments", "vehicles"
 end

--- a/test/controllers/shipments_controller_test.rb
+++ b/test/controllers/shipments_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class ShipmentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @shipment = shipments(:one)
+  end
+
+  test "should get index" do
+    get shipments_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_shipment_url
+    assert_response :success
+  end
+
+  test "should create shipment" do
+    assert_difference('Shipment.count') do
+      post shipments_url, params: { shipment: { cargo_checker: @shipment.cargo_checker, customer_id: @shipment.customer_id, date: @shipment.date, dock: @shipment.dock, driver_id: @shipment.driver_id, hour: @shipment.hour, invoice_number: @shipment.invoice_number, shipment_type: @shipment.shipment_type, vehicle_id: @shipment.vehicle_id, warehouse: @shipment.warehouse } }
+    end
+
+    assert_redirected_to shipment_url(Shipment.last)
+  end
+
+  test "should show shipment" do
+    get shipment_url(@shipment)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_shipment_url(@shipment)
+    assert_response :success
+  end
+
+  test "should update shipment" do
+    patch shipment_url(@shipment), params: { shipment: { cargo_checker: @shipment.cargo_checker, customer_id: @shipment.customer_id, date: @shipment.date, dock: @shipment.dock, driver_id: @shipment.driver_id, hour: @shipment.hour, invoice_number: @shipment.invoice_number, shipment_type: @shipment.shipment_type, vehicle_id: @shipment.vehicle_id, warehouse: @shipment.warehouse } }
+    assert_redirected_to shipment_url(@shipment)
+  end
+
+  test "should destroy shipment" do
+    assert_difference('Shipment.count', -1) do
+      delete shipment_url(@shipment)
+    end
+
+    assert_redirected_to shipments_url
+  end
+end

--- a/test/fixtures/drivers.yml
+++ b/test/fixtures/drivers.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   first_name: MyString
   last_name: MyString

--- a/test/fixtures/shipments.yml
+++ b/test/fixtures/shipments.yml
@@ -1,0 +1,23 @@
+one:
+  driver: one
+  vehicle: one
+  customer: one
+  shipment_type: 1
+  invoice_number: MyString
+  cargo_checker: MyString
+  warehouse: 1
+  dock: MyString
+  date: 2021-05-26
+  hour: 2021-05-26 21:29:12
+
+two:
+  driver: two
+  vehicle: two
+  customer: two
+  shipment_type: 1
+  invoice_number: MyString
+  cargo_checker: MyString
+  warehouse: 1
+  dock: MyString
+  date: 2021-05-26
+  hour: 2021-05-26 21:29:12

--- a/test/fixtures/vehicles.yml
+++ b/test/fixtures/vehicles.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   manufacturer: MyString
   model: MyString

--- a/test/models/driver_test.rb
+++ b/test/models/driver_test.rb
@@ -1,7 +1,5 @@
 require 'test_helper'
 
 class DriverTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
 end

--- a/test/models/shipment_test.rb
+++ b/test/models/shipment_test.rb
@@ -1,0 +1,5 @@
+require 'test_helper'
+
+class ShipmentTest < ActiveSupport::TestCase
+
+end

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -1,7 +1,5 @@
 require 'test_helper'
 
 class VehicleTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
 end

--- a/test/system/shipments_test.rb
+++ b/test/system/shipments_test.rb
@@ -1,0 +1,61 @@
+require "application_system_test_case"
+
+class ShipmentsTest < ApplicationSystemTestCase
+  setup do
+    @shipment = shipments(:one)
+  end
+
+  test "visiting the index" do
+    visit shipments_url
+    assert_selector "h1", text: "Shipments"
+  end
+
+  test "creating a Shipment" do
+    visit shipments_url
+    click_on "New Shipment"
+
+    fill_in "Cargo checker", with: @shipment.cargo_checker
+    fill_in "Customer", with: @shipment.customer_id
+    fill_in "Date", with: @shipment.date
+    fill_in "Dock", with: @shipment.dock
+    fill_in "Driver", with: @shipment.driver_id
+    fill_in "Hour", with: @shipment.hour
+    fill_in "Invoice number", with: @shipment.invoice_number
+    fill_in "Shipment type", with: @shipment.shipment_type
+    fill_in "Vehicle", with: @shipment.vehicle_id
+    fill_in "Warehouse", with: @shipment.warehouse
+    click_on "Create Shipment"
+
+    assert_text "Shipment was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Shipment" do
+    visit shipments_url
+    click_on "Edit", match: :first
+
+    fill_in "Cargo checker", with: @shipment.cargo_checker
+    fill_in "Customer", with: @shipment.customer_id
+    fill_in "Date", with: @shipment.date
+    fill_in "Dock", with: @shipment.dock
+    fill_in "Driver", with: @shipment.driver_id
+    fill_in "Hour", with: @shipment.hour
+    fill_in "Invoice number", with: @shipment.invoice_number
+    fill_in "Shipment type", with: @shipment.shipment_type
+    fill_in "Vehicle", with: @shipment.vehicle_id
+    fill_in "Warehouse", with: @shipment.warehouse
+    click_on "Update Shipment"
+
+    assert_text "Shipment was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Shipment" do
+    visit shipments_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Shipment was successfully destroyed"
+  end
+end


### PR DESCRIPTION
## Add Shipments Table
---
### Context

Add the Shipments table to the project and create the appropriate relationships with the Vehicles, Drivers and Customers tables.

### Content

- [x] Generate Shipment scaffold
- [x] Add table relationship using has_many: _table_, through: _:table_
- [x] Add enum options to the shipiments model
- [x] Add the select field to the views to use in Warehouse and Shipment Type fields
- [x] Remove default comments